### PR TITLE
Added default to 'en-US'

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -42,7 +42,7 @@ var LocalizedStrings = (function () {
   function LocalizedStrings(props) {
     _classCallCheck(this, LocalizedStrings);
 
-    var interfaceLanguage = navigator.language || navigator.userLanguage;
+    var interfaceLanguage = navigator.language || navigator.userLanguage || 'en-US';
     //Store locally the passed strings
     this.props = props;
     //Set language to its default value (the interface)


### PR DESCRIPTION
In react-native navigator.language || navigator.interfaceLanguage returns undefined. So added default to 'en-US' rather than device locale.