### PR TITLE
Fix so the navigator.languages array is used by default

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
- * Simple module to localize the React interface using the same syntax 
- * used in the ReactNativeLocalization module 
+ * Simple module to localize the React interface using the same syntax
+ * used in the ReactNativeLocalization module
  * (https://github.com/stefalda/ReactNativeLocalization)
  *
  * Originally developed by Stefano Falda (stefano.falda@gmail.com)
@@ -42,7 +42,7 @@ var LocalizedStrings = (function () {
   function LocalizedStrings(props) {
     _classCallCheck(this, LocalizedStrings);
 
-    var interfaceLanguage = navigator.language || navigator.userLanguage || 'en-US';
+    var interfaceLanguage = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || 'en-US');
     //Store locally the passed strings
     this.props = props;
     //Set language to its default value (the interface)

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
- * Simple module to localize the React interface using the same syntax 
- * used in the ReactNativeLocalization module 
+ * Simple module to localize the React interface using the same syntax
+ * used in the ReactNativeLocalization module
  * (https://github.com/stefalda/ReactNativeLocalization)
  *
  * Originally developed by Stefano Falda (stefano.falda@gmail.com)
@@ -31,7 +31,7 @@ export default class LocalizedStrings{
 
 
   constructor(props) {
-    let interfaceLanguage = (navigator.language || navigator.userLanguage);
+    let interfaceLanguage = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || 'en-US');
     //Store locally the passed strings
     this.props = props;
     //Set language to its default value (the interface)


### PR DESCRIPTION
In Chrome, the `navigator.language` never changes when the user changes their preferred language. It is always set to the language the browser was downloaded in. Instead we have to look into the read-only array `navigator.languages` to find their preferred language. Safari and IE however don't use `navigator.languages` so we still need to fall back to `navigator.language || navigator.userLanguage`. And I left the `|| 'en-US'` just incase.

See https://alicoding.com/detect-browser-language-preference-in-firefox-and-chrome-using-javascript/ for reference.