### PR TITLE
Enable to import interfaces from d.ts

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -1,17 +1,18 @@
+
+interface LocalizedStringsMethods {
+    setLanguage(language: string): void;
+    getLanguage(): string;
+    getInterfaceLanguage(): string;
+    formatString(str: string, ...values: any[]): string;
+    getAvailableLanguages(): string[];
+    getString(key:string, language:string):string;
+}
+
+interface LocalizedStringsFactory {
+    new (props: any): LocalizedStringsMethods;
+}
+
 declare module "react-localization" {
-    interface LocalizedStringsMethods {
-        setLanguage(language: string): void;
-        getLanguage(): string;
-        getInterfaceLanguage(): string;
-        formatString(str: string, ...values: any[]): string;
-        getAvailableLanguages(): string[];
-        getString(key:string, language:string):string;
-    }
-
-    interface LocalizedStringsFactory {
-        new (props: any): LocalizedStringsMethods;
-    }
-
     var LocalizedStrings: LocalizedStringsFactory;
     export = LocalizedStrings;
 }


### PR DESCRIPTION
Hi guys thank you for your good OSS. I want to join it !
I want to use LocalizedStringsFactory from `LocalizedStrings.d.ts` but I can not use it.

According to `jQuery`, `JQuery` (large J not j) is defined as interface out of the `declare module "jquery" { ... }` so that we can use it like `var jquery: JQuery`
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/index.d.ts#L1402

Because I'm a newbie of typescript, I'm not sure my PR is correct.
If I'm wrong plz tell me m(_ _)m