### PR TITLE
Add ability to use React components in formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Then use the `strings` object literal directly in the render method accessing th
 * getLanguage() - to get the current displayed language
 * getInterfaceLanguage() - to get the current device interface language
 * formatString() - to format the passed string replacing its placeholders with the other arguments strings
-* setContent(props) - to dynamically load another set of strings
 ```js
   en:{
     bread:"bread",
@@ -60,6 +59,7 @@ Then use the `strings` object literal directly in the render method accessing th
   strings.formatString(strings.question, strings.bread, strings.butter)
 ```
 **Beware: do not define a string key as formatString!**
+* setContent(props) - to dynamically load another set of strings
 * getAvailableLanguages() - to get an array of the languages passed in the constructor
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then use the `strings` object literal directly in the render method accessing th
   en:{
     bread:"bread",
     butter:"butter",
-    question:"I'd like {0} and {1}, or just {0}",
+    question:"I'd like {0} and {1}, or just {0}"
     ...
     login: 'login',
     onlyForMembers: 'You have to {0} in order to use our app',

--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@ Then use the `strings` object literal directly in the render method accessing th
   en:{
     bread:"bread",
     butter:"butter",
-    question:"I'd like {0} and {1}, or just {0}"
+    question:"I'd like {0} and {1}, or just {0}",
+    ...
+    login: 'login',
+    onlyForMembers: 'You have to {0} in order to use our app',
+    bold: 'bold',
+    iAmText: 'I am {0} text',
   }
   ...
   strings.formatString(strings.question, strings.bread, strings.butter)
+
+  // you can also use React component as placeholder values! Useful when using links or customizing style
+  strings.formatString(strings.onlyForMembers, <a href="http://login.com">{strings.login}</a>)
+  strings.formatString(strings.iAmText, <b>{strings.bold}</b>)
 ```
 **Beware: do not define a string key as formatString!**
 * setContent(props) - to dynamically load another set of strings

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -1,4 +1,23 @@
 'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 /**
  * Simple module to localize the React interface using the same syntax
  * used in the ReactNativeLocalization module
@@ -15,16 +34,13 @@
  * https://github.com/stefalda/react-localization
  */
 
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+var placeholderRegex = /(\{\d+\})/;
+var isReactComponent = function isReactComponent(value) {
+    return _typeof(value.$$typeof) === 'symbol';
+};
 
 var DEFAULT_VALUE = 'en-US';
-var reservedNames = ["_getInterfaceLanguage", "_getBestMatchingLanguage", "setContent", "_interfaceLanguage", "_defaultLanguage", "_defaultLanguageFirstLevelKeys", "_props"];
+var reservedNames = ['_interfaceLanguage', '_language', '_defaultLanguage', '_defaultLanguageFirstLevelKeys', '_props'];
 
 var LocalizedStrings = function () {
     _createClass(LocalizedStrings, [{
@@ -84,10 +100,8 @@ var LocalizedStrings = function () {
     }, {
         key: '_validateProps',
         value: function _validateProps(props) {
-            var _this = this;
-
             Object.keys(props).map(function (key) {
-                if (_this.hasOwnProperty(key)) throw new Error(key + ' cannot be used as a key. It is a reserved word.');
+                if (reservedNames.indexOf(key) >= 0) throw new Error(key + ' cannot be used as a key. It is a reserved word.');
             });
         }
 
@@ -201,16 +215,19 @@ var LocalizedStrings = function () {
     }, {
         key: 'formatString',
         value: function formatString(str) {
-            var res = str;
-
-            for (var _len = arguments.length, values = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-                values[_key - 1] = arguments[_key];
+            for (var _len = arguments.length, valuesForPlaceholders = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+                valuesForPlaceholders[_key - 1] = arguments[_key];
             }
 
-            for (var i = 0; i < values.length; i++) {
-                res = this._replaceAll("{" + i + "}", values[i], res);
-            }
-            return res;
+            return str.split(placeholderRegex).map(function (textPart, index) {
+                if (textPart.match(placeholderRegex)) {
+                    var valueForPlaceholder = valuesForPlaceholders[textPart.slice(1, -1)];
+                    return isReactComponent(valueForPlaceholder) ? _react2.default.Children.toArray(valueForPlaceholder).map(function (component) {
+                        return _extends({}, component, { key: index });
+                    }) : valueForPlaceholder;
+                }
+                return textPart;
+            });
         }
 
         //Return a string with the passed key in a different language 
@@ -224,16 +241,6 @@ var LocalizedStrings = function () {
                 console.log("No localization found for key " + key + " and language " + language);
             }
             return null;
-        }
-
-        //Replace all occurrences of a string in another using RegExp
-
-    }, {
-        key: '_replaceAll',
-        value: function _replaceAll(find, replace, str) {
-            //Escape find
-            find = find.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
-            return str.replace(new RegExp(find, 'g'), replace);
         }
     }]);
 

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -153,8 +153,9 @@ export default class LocalizedStrings {
     //Use example:
     //  strings.formatString(strings.question, strings.bread, strings.butter)
     formatString(str, ...values) {
-        if (values.some(isReactComponent)) {
-            const result = str.split(placeholderRegex).map((textPart, index) => {
+        return str
+            .split(placeholderRegex)
+            .map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
                     const valueForPlaceholder = values[parseInt(textPart.slice(1, -1))];
                     if (isReactComponent(valueForPlaceholder)) {
@@ -165,15 +166,6 @@ export default class LocalizedStrings {
                 }
                 return textPart;
             });
-            return result;
-        }
-        else {
-            let res = str;
-            for (let i = 0; i < values.length; i++) {
-                res = this._replaceAll("{" + i + "}", values[i], res); //
-            }
-            return res;
-        }
     }
 
     //Return a string with the passed key in a different language 

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -175,11 +175,4 @@ export default class LocalizedStrings {
         }
         return null;
     }
-
-    //Replace all occurrences of a string in another using RegExp
-    _replaceAll(find, replace, str) {
-        //Escape find
-        find = find.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
-        return str.replace(new RegExp(find, 'g'), replace);
-    }
 }

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -158,11 +158,9 @@ export default class LocalizedStrings {
             .map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
                     const valueForPlaceholder = values[parseInt(textPart.slice(1, -1))];
-                    if (isReactComponent(valueForPlaceholder)) {
-                        return React.Children.toArray(valueForPlaceholder)
-                            .map(component => ({...component, key: index}));
-                    }
-                    return valueForPlaceholder;
+                    return isReactComponent(valueForPlaceholder)
+                        ? React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index}))
+                        : valueForPlaceholder;
                 }
                 return textPart;
             });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -157,7 +157,7 @@ export default class LocalizedStrings {
             .split(placeholderRegex)
             .map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
-                    const valueForPlaceholder = values[parseInt(textPart.slice(1, -1))];
+                    const valueForPlaceholder = values[textPart.slice(1, -1)];
                     return isReactComponent(valueForPlaceholder)
                         ? React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index}))
                         : valueForPlaceholder;

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -156,12 +156,12 @@ export default class LocalizedStrings {
         if (values.some(isReactComponent)) {
             const result = str.split(placeholderRegex).map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
-                    const reactComponent = values[parseInt(textPart.slice(1, -1))];
-                    if (isReactComponent(reactComponent)) {
-                        return React.Children.toArray(reactComponent)
+                    const valueForPlaceholder = values[parseInt(textPart.slice(1, -1))];
+                    if (isReactComponent(valueForPlaceholder)) {
+                        return React.Children.toArray(valueForPlaceholder)
                             .map(component => ({...component, key: index}));
                     }
-                    return reactComponent;
+                    return valueForPlaceholder;
                 }
                 return textPart;
             });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -152,12 +152,12 @@ export default class LocalizedStrings {
     //i.e. I'd like some {0} and {1}, or just {0}
     //Use example:
     //  strings.formatString(strings.question, strings.bread, strings.butter)
-    formatString(str, ...values) {
+    formatString(str, ...valuesForPlaceholders) {
         return str
             .split(placeholderRegex)
             .map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
-                    const valueForPlaceholder = values[textPart.slice(1, -1)];
+                    const valueForPlaceholder = valuesForPlaceholders[textPart.slice(1, -1)];
                     return isReactComponent(valueForPlaceholder)
                         ? React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index}))
                         : valueForPlaceholder;


### PR DESCRIPTION
## Motivation
Situation where you have a link inside of string that you have to translate like this:

![image](https://user-images.githubusercontent.com/12229968/28072080-834bc45e-665a-11e7-97c6-83a4a1964a62.png)

Now in order to get result like above now you can do it like this:
```js
import LocalizedStrings from 'react-localization';

const strings = new LocalizedStrings({
  fi: {
    login: 'kirjautua sisään',
    membersOnly: 'Sinun täytyy {0} jotta voit käyttää ohjelmaamme',
  },
  en: {
    login: 'login',
    membersOnly: 'You have to {0} in order to use our app',
  },
});

const ExampleComponent = () => (
  <div>
    <h1>Hello everyone!</h1>
    {strings.formatString(strings.membersOnly, <a href="http://login.com">{strings.login}</a>)}
  </div>
);
```

You can use any React component inside translated text now but I think most common ones are `a` for links and maybe `b` for making particular part bold etc :D tell me if there is anything that needs to be fixed since for some reason I could not run tests. Maybe someone can help me with that?

PS if this gets merged the next version bumb according to semantic versioning should be `0.1.0` since this adds a new feature but is backwards compatible :)

> Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards compatible functionality is introduced to the public API. It MUST be incremented if any public API functionality is marked as deprecated. It MAY be incremented if substantial new functionality or improvements are introduced within the private code. It MAY include patch level changes. Patch version MUST be reset to 0 when minor version is incremented.