### PR TITLE
Add tests for formatString with React components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-2"]
+  "presets": ["es2015", "stage-2", "react"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,12 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true
     },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+      "dev": true
+    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -216,6 +222,18 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -392,10 +410,40 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true
     },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "dev": true
     },
     "babel-plugin-transform-regenerator": {
@@ -420,6 +468,18 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "dev": true
     },
     "babel-preset-stage-2": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.22.0",
     "jasmine": "^2.6.0",
     "jasmine-core": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.22.0",
-    "jasmine": "^2.6.0",
-    "jasmine-core": "^2.6.2"
+    "jasmine": "^2.6.0"
   },
   "dependencies": {
     "react": "^15.6.1"

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import LocalizedStrings from '../src/LocalizedStrings';
 
 describe('Main Library Functions', function () {
@@ -131,5 +133,21 @@ describe('Main Library Functions', function () {
         }
       });
     }).toThrow(new Error("_language cannot be used as a key. It is a reserved word."));
+  });
+
+  describe('formatString with React components', () => {
+    let newStrings = new LocalizedStrings({
+      en: {
+        onlyForMembers: "Only who have {0} can enter",
+      },
+      fi: {
+        onlyForMembers: "Vain {0} voivat tulla",
+      }
+    });
+    
+    it('adds React component', () => {
+      expect(newStrings.formatString(newStrings.onlyForMembers, <a href="#">logged in</a>))
+        .toEqual(["Only who have ", [<a href="#" key={1}>logged in</a>], " can enter"]);
+    });
   });
 });

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -139,15 +139,22 @@ describe('Main Library Functions', function () {
     let newStrings = new LocalizedStrings({
       en: {
         onlyForMembers: "Only who have {0} can enter",
+        onlyForMembersStrong: "Only who have {0} can {1}",
       },
       fi: {
         onlyForMembers: "Vain {0} voivat tulla",
+        onlyForMembersStrong: "Vain {0} voivat {1}",
       }
     });
-    
-    it('adds React component', () => {
+
+    it('one React component', () => {
       expect(newStrings.formatString(newStrings.onlyForMembers, <a href="#">logged in</a>))
-        .toEqual(["Only who have ", [<a href="#" key={1}>logged in</a>], " can enter"]);
+        .toEqual(["Only who have ", [<a href="#" key="1">logged in</a>], " can enter"]);
+    });
+
+    it('two React component', () => {
+      expect(newStrings.formatString(newStrings.onlyForMembersStrong, <a href="#">logged in</a>, <b>enter</b>))
+        .toEqual(["Only who have ", [<a href="#" key="1">logged in</a>], " can ", [<b key="3">enter</b>]]);
     });
   });
 });

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -136,25 +136,32 @@ describe('Main Library Functions', function () {
   });
 
   describe('formatString with React components', () => {
-    let newStrings = new LocalizedStrings({
+    const reactStrings = new LocalizedStrings({
       en: {
         onlyForMembers: "Only who have {0} can enter",
         onlyForMembersStrong: "Only who have {0} can {1}",
+        helloThere: "Hello {0}! Are you sure {0} is your name?",
       },
       fi: {
         onlyForMembers: "Vain {0} voivat tulla",
         onlyForMembersStrong: "Vain {0} voivat {1}",
+        helloThere: "Moi {0}! Onko {0} varmasti nimesi?",
       }
     });
 
     it('one React component', () => {
-      expect(newStrings.formatString(newStrings.onlyForMembers, <a href="#">logged in</a>))
+      expect(reactStrings.formatString(reactStrings.onlyForMembers, <a href="#">logged in</a>))
         .toEqual(["Only who have ", [<a href="#" key="1">logged in</a>], " can enter"]);
     });
 
     it('two React component', () => {
-      expect(newStrings.formatString(newStrings.onlyForMembersStrong, <a href="#">logged in</a>, <b>enter</b>))
+      expect(reactStrings.formatString(reactStrings.onlyForMembersStrong, <a href="#">logged in</a>, <b>enter</b>))
         .toEqual(["Only who have ", [<a href="#" key="1">logged in</a>], " can ", [<b key="3">enter</b>]]);
+    });
+
+    it('one React component in one string', () => {
+      expect(reactStrings.formatString(reactStrings.helloThere, <i>Henrik</i>))
+        .toEqual(["Hello ", [<i key="1">Henrik</i>], "! Are you sure ", [<i key="3">Henrik</i>], " is your name?"]);
     });
   });
 });

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -159,7 +159,7 @@ describe('Main Library Functions', function () {
         .toEqual(["Only who have ", [<a href="#" key="1">logged in</a>], " can ", [<b key="3">enter</b>]]);
     });
 
-    it('one React component in one string', () => {
+    it('one React component twice in a string', () => {
       expect(reactStrings.formatString(reactStrings.helloThere, <i>Henrik</i>))
         .toEqual(["Hello ", [<i key="1">Henrik</i>], "! Are you sure ", [<i key="3">Henrik</i>], " is your name?"]);
     });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -146,7 +146,7 @@ export default class LocalizedStrings {
                 if (textPart.match(placeholderRegex)) {
                     const valueForPlaceholder = valuesForPlaceholders[textPart.slice(1, -1)];
                     return isReactComponent(valueForPlaceholder)
-                        ? React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index}))
+                        ? React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index.toString()}))
                         : valueForPlaceholder;
                 }
                 return textPart;


### PR DESCRIPTION
- add babel-react-preset to be able to use JSX in tests
- all tests pass
- tested with my project that this library still works 
- remove jasmine-core