### PR TITLE
Fix LocalizedStrings.d.ts exporting default

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -14,5 +14,5 @@ declare module "react-localization" {
     }
 
     var LocalizedStrings: LocalizedStringsFactory;
-    export = LocalizedStrings;
+    export default LocalizedStrings;
 }


### PR DESCRIPTION
The way `LocalizedStrings.js` is defined, it is exposing `LocalizedStrings` as the default:

```js
exports.default = LocalizedStrings;
```

This fixes the TypeScript definition fine by marking the export as such. The current definition file is broken, because either:

1) You import the module in TS, which will crash at runtime because you need to use `.default` instead.
2) Use `.default`, and TS compiler will error out because the definition has no default export.