### PR TITLE
Handle components in named tokens

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -205,19 +205,20 @@ var LocalizedStrings = function () {
                 return !!textPart;
             }).map(function (textPart, index) {
                 if (textPart.match(placeholderRegex)) {
-                    var matchedKey = textPart.slice(1, -1),
-                        valueForPlaceholder = valuesForPlaceholders[matchedKey];
+                    var matchedKey = textPart.slice(1, -1);
+                    var valueForPlaceholder = valuesForPlaceholders[matchedKey];
 
-                    if (valueForPlaceholder) {
-                        if (isReactComponent(valueForPlaceholder)) {
-                            return _react2.default.Children.toArray(valueForPlaceholder).map(function (component) {
-                                return _extends({}, component, { key: index.toString() });
-                            });
-                        }
-                        return valueForPlaceholder;
-                    } else {
-                        return valuesForPlaceholders[0][matchedKey];
+                    if (!valueForPlaceholder) {
+                        valueForPlaceholder = valuesForPlaceholders[0][matchedKey];
                     }
+
+                    if (isReactComponent(valueForPlaceholder)) {
+                        return _react2.default.Children.toArray(valueForPlaceholder).map(function (component) {
+                            return _extends({}, component, { key: index.toString() });
+                        });
+                    }
+
+                    return valueForPlaceholder;
                 }
                 return textPart;
             });

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -130,7 +130,8 @@ describe('Main Library Functions', function () {
         onlyForMembers: "Only who have {0} can enter",
         onlyForMembersStrong: "Only who have {0} can {1}",
         helloThere: "Hello {0}! Are you sure {0} is your name?",
-        namedTokens: "The current date is {month} {day}, {year}!",
+        currentDate: "The current date is {month} {day}, {year}!",
+        boldText: "Some {bold} text"
       },
       fi: {
         onlyForMembers: "Vain {0} voivat tulla",
@@ -160,8 +161,14 @@ describe('Main Library Functions', function () {
         day: "12",
         year: "2018"
       };
-      expect(reactStrings.formatString(reactStrings.namedTokens, formatTokens))
+      expect(reactStrings.formatString(reactStrings.currentDate, formatTokens))
         .toEqual(["The current date is ", "January", " ", "12", ", ", "2018", "!"]);
-    })
+    });
+
+    it('Handles named tokens with components', () => {
+      expect(reactStrings.formatString(reactStrings.boldText, {
+        bold: <span className="bold">BOLD</span>
+      })).toEqual(["Some ", [<span key="1" className="bold">BOLD</span>], " text"]);
+    });
   });
 });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -133,17 +133,18 @@ export default class LocalizedStrings {
             .filter(textPart => !!textPart)
             .map((textPart, index) => {
                 if (textPart.match(placeholderRegex)) {
-                    const matchedKey = textPart.slice(1, -1),
-                          valueForPlaceholder = valuesForPlaceholders[matchedKey];
+                    const matchedKey = textPart.slice(1, -1);
+                    let valueForPlaceholder = valuesForPlaceholders[matchedKey];
 
-                    if(valueForPlaceholder) {
-                      if(isReactComponent(valueForPlaceholder)) {
-                        return React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index.toString()}));
-                      }
-                      return valueForPlaceholder;
-                    } else {
-                      return valuesForPlaceholders[0][matchedKey];
+                    if(!valueForPlaceholder) {
+                      valueForPlaceholder = valuesForPlaceholders[0][matchedKey];
                     }
+
+                    if(isReactComponent(valueForPlaceholder)) {
+                      return React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index.toString()}));
+                    }
+
+                    return valueForPlaceholder;
                 }
                 return textPart;
             });


### PR DESCRIPTION
Just noticed my named token code didn't handle components properly 😅 React was complaining about missing the key prop. Sorry about that. I added a unit test to make sure it will work as expected now, plus tested on my own site to confirm.