### PR TITLE
Handle falsy values

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -208,8 +208,15 @@ var LocalizedStrings = function () {
                     var matchedKey = textPart.slice(1, -1);
                     var valueForPlaceholder = valuesForPlaceholders[matchedKey];
 
-                    if (!valueForPlaceholder) {
-                        valueForPlaceholder = valuesForPlaceholders[0][matchedKey];
+                    // If no value found, check if working with an object instead
+                    if (valueForPlaceholder == undefined) {
+                        var valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
+                        if (valueFromObjectPlaceholder !== undefined) {
+                            valueForPlaceholder = valueFromObjectPlaceholder;
+                        } else {
+                            // If value still isn't found, then it must have been undefined/null
+                            return valueForPlaceholder;
+                        }
                     }
 
                     if (isReactComponent(valueForPlaceholder)) {

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -4,32 +4,41 @@ import LocalizedStrings from '../src/LocalizedStrings';
 
 describe('Main Library Functions', function () {
   global.navigator = {};
-  let strings = new LocalizedStrings({
-    en: {
-      language:"english",
-      how:"How do you want your egg today?",
-      boiledEgg:"Boiled egg",
-      softBoiledEgg:"Soft-boiled egg",
-      choice:"How to choose the egg",
-      formattedValue:"I'd like some {0} and {1}, or just {0}",
-      ratings: {
-        excellent:"excellent",
-        good:"good",
-        missingComplex:"missing value"
+  let strings;
+
+  beforeEach(() => {
+    strings = new LocalizedStrings({
+      en: {
+        language:"english",
+        how:"How do you want your egg today?",
+        boiledEgg:"Boiled egg",
+        softBoiledEgg:"Soft-boiled egg",
+        choice:"How to choose the egg",
+        formattedValue:"I'd like some {0} and {1}, or just {0}",
+        ratings: {
+          excellent:"excellent",
+          good:"good",
+          missingComplex:"missing value"
+        },
+        missing:"missing value",
+        currentDate: "The current date is {month} {day}, {year}!",
+        falsy: "{0} {1} {2} {3} {4} {5}"
       },
-      missing:"missing value"
-    },
-    it: {
-      how:"Come vuoi il tuo uovo oggi?",
-      boiledEgg:"Uovo sodo",
-      softBoiledEgg:"Uovo alla coque",
-      choice:"Come scegliere l'uovo",
-      ratings: {
-        excellent:"eccellente",
-        good:"buono"
-      },
-      formattedValue:"Vorrei un po' di {0} e {1}, o solo {0}",
-    }
+      it: {
+        language: "italian",
+        how:"Come vuoi il tuo uovo oggi?",
+        boiledEgg:"Uovo sodo",
+        softBoiledEgg:"Uovo alla coque",
+        choice:"Come scegliere l'uovo",
+        ratings: {
+          excellent:"eccellente",
+          good:"buono"
+        },
+        formattedValue:"Vorrei un po' di {0} e {1}, o solo {0}",
+        currentDate: "La data corrente è {month} {day}, {year}!",
+        falsy: "{0} {1} {2} {3} {4} {5}"
+      }
+    });
   });
 
   it("Set default language to en", function(){
@@ -64,26 +73,33 @@ describe('Main Library Functions', function () {
     expect(strings.getLanguage()).toEqual("it");
   });
   it('Extract simple value from  other language', function () {
+    strings.setLanguage("it");
     expect(strings.how).toEqual('Come vuoi il tuo uovo oggi?');
   });
 
   it('Extract complex value from other language', function () {
+    strings.setLanguage("it");
     expect(strings.ratings.good).toEqual('buono');
   });
 
   it('Get missing key from other language', function () {
+    strings.setLanguage("it");
     expect(strings.missing).toEqual('missing value');
   });
 
   it('Get complex missing key from other language', function () {
+    strings.setLanguage("it");
     expect(strings.ratings.missingComplex).toEqual('missing value');
   });
+
   it('Format string in other language', function () {
+    strings.setLanguage("it");
     expect(strings.formatString(strings.formattedValue, "torta", "gelato"))
       .toEqual(["Vorrei un po' di ", "torta", " e ", "gelato", ", o solo ", "torta"]);
   });
 
   it('Get string in a different language', function () {
+    strings.setLanguage("it");
     expect(strings.getString("choice", "en")).toBe("How to choose the egg");
   });
 
@@ -124,13 +140,27 @@ describe('Main Library Functions', function () {
     expect(strings.a.b.x).toEqual('a.b.x');
   });
 
+  it('Handles named tokens as part of the format string', () => {
+    const formatTokens = {
+      month: "January",
+      day: "12",
+      year: "2018"
+    };
+    expect(strings.formatString(strings.currentDate, formatTokens))
+      .toEqual(["The current date is ", "January", " ", "12", ", ", "2018", "!"]);
+  });
+
+  it('Handles falsy values', () => {
+    expect(strings.formatString(strings.falsy, 0, false, '', null, undefined, NaN))
+      .toEqual([0, " ", false, " ", '', " ", null, " ", undefined, " ", NaN]);
+  });
+
   describe('formatString with React components', () => {
     const reactStrings = new LocalizedStrings({
       en: {
         onlyForMembers: "Only who have {0} can enter",
         onlyForMembersStrong: "Only who have {0} can {1}",
         helloThere: "Hello {0}! Are you sure {0} is your name?",
-        currentDate: "The current date is {month} {day}, {year}!",
         boldText: "Some {bold} text"
       },
       fi: {
@@ -153,16 +183,6 @@ describe('Main Library Functions', function () {
     it('one React component twice in a string', () => {
       expect(reactStrings.formatString(reactStrings.helloThere, <i>Henrik</i>))
         .toEqual(["Hello ", [<i key="1">Henrik</i>], "! Are you sure ", [<i key="3">Henrik</i>], " is your name?"]);
-    });
-
-    it('Handles named tokens as part of the format string', () => {
-      const formatTokens = {
-        month: "January",
-        day: "12",
-        year: "2018"
-      };
-      expect(reactStrings.formatString(reactStrings.currentDate, formatTokens))
-        .toEqual(["The current date is ", "January", " ", "12", ", ", "2018", "!"]);
     });
 
     it('Handles named tokens with components', () => {

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -136,8 +136,15 @@ export default class LocalizedStrings {
                     const matchedKey = textPart.slice(1, -1);
                     let valueForPlaceholder = valuesForPlaceholders[matchedKey];
 
-                    if(!valueForPlaceholder) {
-                      valueForPlaceholder = valuesForPlaceholders[0][matchedKey];
+                    // If no value found, check if working with an object instead
+                    if(valueForPlaceholder == undefined) {
+                      const valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
+                      if(valueFromObjectPlaceholder !== undefined) {
+                        valueForPlaceholder = valueFromObjectPlaceholder;
+                      } else {
+                        // If value still isn't found, then it must have been undefined/null
+                        return valueForPlaceholder;
+                      }
                     }
 
                     if(isReactComponent(valueForPlaceholder)) {


### PR DESCRIPTION
- If values are falsy, handle them correctly in formatString
- Add unit test to cover functionality
- Refactor unit tests a bit, the strings object was being overwritten by the tests and wasn't being reset again afterwards

Fixes #62