### PR TITLE
fix: bump localized-strings version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2422,9 +2422,9 @@
       }
     },
     "localized-strings": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/localized-strings/-/localized-strings-0.0.4.tgz",
-      "integrity": "sha512-pu8nld52jPwinmRHWbyTSqW4p6Z+wcqU+Jg3d2pohZ1PleB1UVkPRmvgPzYPs5yUY3K9AMd8+rh/+Aoq4iozQA=="
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/localized-strings/-/localized-strings-0.0.11.tgz",
+      "integrity": "sha512-PULau66/AWtyr3Cov//BBe5UaKCNkL7ufTTXnRdaP4bJHmg7SxteUWJJ63bBOv7AL29OkgxEuN0ZTobiXLRsfQ=="
     },
     "lodash": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine": "^2.7.0"
   },
   "dependencies": {
-    "localized-strings": "^0.0.10",
+    "localized-strings": "^0.0.11",
     "react": "^16.0.0"
   }
 }


### PR DESCRIPTION
Hiya,

I couldn't get this version number to bump by itself, even though your `package.json` should allow for that with the `^0.0.10` in it.

I deleted my local `package-lock.json` and my `node_modules` folders, but alas, still ended up with `0.0.10` installed.

If you accept and merge that would  be cool, otherwise I can definitely make another plan :)