### PR TITLE
Use React.isValidElement which covers non-Symbol supporting environments

### DIFF
--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -20,7 +20,6 @@
 
 import React from 'react';
 import LocalizedStrings from 'localized-strings';
-const isReactComponent = value => typeof value.$$typeof === 'symbol';
 const placeholderRegex = /(\{[\d|\w]+\})/;
 
 /**
@@ -54,7 +53,7 @@ LocalizedStrings.prototype.formatString = (str, ...valuesForPlaceholders) => {
                       }
                     }
 
-                    if(isReactComponent(valueForPlaceholder)) {
+                    if(React.isValidElement(valueForPlaceholder)) {
                       hasObject = true;
                       return React.Children.toArray(valueForPlaceholder).map(component => ({...component, key: index.toString()}));
                     }


### PR DESCRIPTION
Fixes #81.

On older devices, the JavaScriptCore version (used by the RN engine) does not support Symbols. Hence, the function `isReactComponent` at https://github.com/stefalda/react-localization/blob/master/src/LocalizedStrings.js#L23 will always return false. So `formatString` will try to concatenate the React elements along with strings, resulting in issue #81.

This MR proposes the usage of `React.isValidElement` instead, which supports older JS engines where Symbols are not supported. 