### PR TITLE
Fix formatString return type

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -31,7 +31,7 @@ declare module 'react-localization' {
          * Use example:
          *   strings.formatString(strings.question, strings.bread, strings.butter)
          */
-        formatString<T extends Formatted>(str: string, ...values: Array<T | FormatObject<T>>): Array<string | T> | string;
+        formatString<T extends Formatted>(str: string, ...values: Array<T | FormatObject<T>>): string;
 
         /**
          * Return an array containing the available languages passed as props in the constructor


### PR DESCRIPTION
From my understanding, based on https://github.com/stefalda/react-localization/issues/46, it should only ever return a string now.